### PR TITLE
Add support for accessing linked accounts, transaction pagination, PDF note parser.

### DIFF
--- a/src/HL.Client/Client.cs
+++ b/src/HL.Client/Client.cs
@@ -62,6 +62,11 @@ namespace HL.Client
         /// Gets or sets the message operations.
         /// </summary>
         public virtual MessageOperations MessageOperations { get; set; }
+
+        /// <summary>
+        /// Gets or sets the linked account operations.
+        /// </summary>
+        public virtual LinkedAccountOperations LinkedAccountOperations { get; set; }
         #endregion
 
         #region Constructor
@@ -73,6 +78,7 @@ namespace HL.Client
             // Setup the operations 
             AccountOperations = new AccountOperations(_requestor);
             MessageOperations = new MessageOperations(_requestor);
+            LinkedAccountOperations = new LinkedAccountOperations(_requestor);
         }
         #endregion
     }

--- a/src/HL.Client/Client.cs
+++ b/src/HL.Client/Client.cs
@@ -70,10 +70,10 @@ namespace HL.Client
         #endregion
 
         #region Constructor
-        public Client()
+        public Client(Requestor requestor = null)
         {
             // Load the requestor
-            _requestor = new Requestor();
+            _requestor = requestor ?? new Requestor();
 
             // Setup the operations 
             AccountOperations = new AccountOperations(_requestor);

--- a/src/HL.Client/Entities/ClientAccountEntity.cs
+++ b/src/HL.Client/Entities/ClientAccountEntity.cs
@@ -1,0 +1,23 @@
+namespace HL.Client.Entities
+{
+    /// <summary>
+    /// Defines a client account.
+    /// </summary>
+    public class ClientAccountEntity
+    {
+        /// <summary>
+        /// Gets or sets the client number.
+        /// </summary>
+        public int ClientNumber { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether it's the currently selected account.
+        /// </summary>
+        public bool CurrentlySelected { get; set; }
+    }
+}

--- a/src/HL.Client/Entities/ContractNoteEntity.cs
+++ b/src/HL.Client/Entities/ContractNoteEntity.cs
@@ -1,0 +1,140 @@
+using System;
+
+namespace HL.Client.Entities
+{
+    /// <summary>
+    /// Defines the type of transaction
+    /// </summary>
+    public enum TransactionType
+    {
+        Unknown,
+        Buy,
+        Sell
+    }
+
+    /// <summary>
+    /// Defines the content of a contract note.
+    /// </summary>
+    public class ContractNoteEntity
+    {
+        /// <summary>
+        /// Gets or sets the transaction type.
+        /// </summary>
+        public TransactionType TransactionType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the contract note id.
+        /// </summary>
+        public string ContractNoteId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the product ISIN code.
+        /// </summary>
+        public string Isin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the order time.
+        /// </summary>
+        public DateTime OrderTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unit name.
+        /// </summary>
+        public string UnitName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unit type.
+        /// </summary>
+        public string UnitType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the quantity.
+        /// </summary>
+        public double Quantity { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unit price in it's local currency.
+        /// </summary>
+        public double UnitPrice { get; set; }
+
+        /// <summary>
+        /// Gets or sets the currency the unit price is in.
+        /// </summary>
+        public string UnitCurrency { get; set; }
+
+        /// <summary>
+        /// Gets or sets the exchange rate used for the transaction.
+        /// </summary>
+        public double ExchangeRate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the unit price when converted to GBP.
+        /// </summary>
+        public double UnitPriceGbp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the commission charged for the transaction.
+        /// </summary>
+        public double Commission { get; set; }
+
+        /// <summary>
+        /// Gets or sets the foreign currency exchange fees charged for the transaction.
+        /// </summary>
+        public double FxCharge { get; set; }
+
+        /// <summary>
+        /// Gets or sets the transfer fee.
+        /// </summary>
+        public double TransferFee { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total amount transacted in GBP exclusive of fees.
+        /// </summary>
+        public double TotalAmountGbpExcludingFees { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total amount transacted in GBP inclusive of fees.
+        /// </summary>
+        public double TotalAmountGbpIncludingFees { get; set; }
+
+        /// <summary>
+        /// Gets or sets the venue where the order has been executed.
+        /// </summary>
+        public string Venue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the order type.
+        /// </summary>
+        public string OrderType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stock symbol (if available).
+        /// </summary>
+        public string Symbol { get; set; }
+
+        /// <summary>
+        /// Gets or sets the account name that conducted the transaction.
+        /// </summary>
+        public string Account { get; set; }
+
+        /// <summary>
+        /// Gets or sets the settlement date for the transaction.
+        /// </summary>
+        public DateTime SettlementDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the notes of the transaction.
+        /// </summary>
+        public string Note { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the person transacting.
+        /// </summary>
+        public string ClientName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the address of the person transacting.
+        /// </summary>
+        public string[] ClientAddress { get; set; }
+    }
+}

--- a/src/HL.Client/Entities/ContractNoteEntity.cs
+++ b/src/HL.Client/Entities/ContractNoteEntity.cs
@@ -50,12 +50,12 @@ namespace HL.Client.Entities
         /// <summary>
         /// Gets or sets the quantity.
         /// </summary>
-        public double Quantity { get; set; }
+        public decimal Quantity { get; set; }
 
         /// <summary>
         /// Gets or sets the unit price in it's local currency.
         /// </summary>
-        public double UnitPrice { get; set; }
+        public decimal UnitPrice { get; set; }
 
         /// <summary>
         /// Gets or sets the currency the unit price is in.
@@ -65,37 +65,37 @@ namespace HL.Client.Entities
         /// <summary>
         /// Gets or sets the exchange rate used for the transaction.
         /// </summary>
-        public double ExchangeRate { get; set; }
+        public decimal ExchangeRate { get; set; }
 
         /// <summary>
         /// Gets or sets the unit price when converted to GBP.
         /// </summary>
-        public double UnitPriceGbp { get; set; }
+        public decimal UnitPriceGbp { get; set; }
 
         /// <summary>
         /// Gets or sets the commission charged for the transaction.
         /// </summary>
-        public double Commission { get; set; }
+        public decimal Commission { get; set; }
 
         /// <summary>
         /// Gets or sets the foreign currency exchange fees charged for the transaction.
         /// </summary>
-        public double FxCharge { get; set; }
+        public decimal FxCharge { get; set; }
 
         /// <summary>
         /// Gets or sets the transfer fee.
         /// </summary>
-        public double TransferFee { get; set; }
+        public decimal TransferFee { get; set; }
 
         /// <summary>
         /// Gets or sets the total amount transacted in GBP exclusive of fees.
         /// </summary>
-        public double TotalAmountGbpExcludingFees { get; set; }
+        public decimal TotalAmountGbpExcludingFees { get; set; }
 
         /// <summary>
         /// Gets or sets the total amount transacted in GBP inclusive of fees.
         /// </summary>
-        public double TotalAmountGbpIncludingFees { get; set; }
+        public decimal TotalAmountGbpIncludingFees { get; set; }
 
         /// <summary>
         /// Gets or sets the venue where the order has been executed.

--- a/src/HL.Client/HL.Client.csproj
+++ b/src/HL.Client/HL.Client.csproj
@@ -23,6 +23,7 @@ This is not an official package.</Description>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.23" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.3" />
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
+    <PackageReference Include="PDFsharp" Version="1.50.5147" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HL.Client/Operations/AccountOperations.cs
+++ b/src/HL.Client/Operations/AccountOperations.cs
@@ -109,7 +109,7 @@ namespace HL.Client.Operations
                 .DocumentNode
                 .Descendants("table")
                 .Where(x => x.HasClass("holdings-table"))
-                .SelectMany(table => table.SelectSingleNode("tbody").Descendants("tr"))
+                .SelectMany(table => table.SelectSingleNode("tbody")?.Descendants("tr") ?? Array.Empty<HtmlNode>())
                 .ToArray();
 
             // Convert into stock holding entities

--- a/src/HL.Client/Operations/LinkedAccountOperations.cs
+++ b/src/HL.Client/Operations/LinkedAccountOperations.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using HL.Client.Entities;
+using HtmlAgilityPack;
+
+namespace HL.Client.Operations
+{
+    public class LinkedAccountOperations
+    {
+        #region Fields
+        private Requestor _requestor;
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Gets a list of all accounts.
+        /// </summary>
+        /// <returns>The list of accounts</returns>
+        public async Task<ClientAccountEntity[]> ListAsync(CancellationToken cancellationToken = default)
+        {
+            // Make request
+            var response = await _requestor.GetAsync("my-accounts");
+
+            HtmlDocument doc = new HtmlDocument();
+            doc.Load(await response.Content.ReadAsStreamAsync().ConfigureAwait(false));
+
+            return ListAccounts(doc);
+        }
+
+        /// <summary>
+        /// Parse the document to extract the list of accounts
+        /// </summary>
+        /// <param name="doc">The document containing account information</param>
+        /// <returns>The list of accounts</returns>
+        public static ClientAccountEntity[] ListAccounts(HtmlDocument doc)
+        {
+            // Get list
+            var list = doc.DocumentNode.Descendants("ul").SingleOrDefault(x => x.HasClass("linked-account-tabs"));
+            if (list == null)
+            {
+                return Array.Empty<ClientAccountEntity>();
+            }
+
+            var listItems = list.Descendants("li").ToArray();
+
+            // For each list item, convert into client account model.
+            ClientAccountEntity[] accounts = new ClientAccountEntity[listItems.Count()];
+            for (int i = 0; i < accounts.Length; i++)
+            {
+                // Get the columns in the rows
+                var link = listItems[i].Descendants("a").Single();
+                var uri = new Uri(link.GetAttributeValue("href", null));
+                var queryString = HttpUtility.ParseQueryString(uri.Query);
+                var clientNo = int.Parse(queryString.Get("client_no"));
+
+                // Create an account
+                accounts[i] = new ClientAccountEntity
+                {
+                    ClientNumber = clientNo,
+                    Name = link.GetAttributeValue("title", "").Replace("(" + clientNo + ")", "").Trim(),
+                    CurrentlySelected = listItems[i].HasClass("current-tab")
+                };
+            }
+
+            return accounts;
+        }
+
+        public async Task<bool> Switch(int clientNumber)
+        {
+            // Make request
+            var response = await _requestor.GetAsync("my-accounts/linked_accounts_control?method=switch&client_no=" + clientNumber);
+
+            HtmlDocument doc = new HtmlDocument();
+            doc.Load(await response.Content.ReadAsStreamAsync().ConfigureAwait(false));
+
+            return ListAccounts(doc).FirstOrDefault(o => o.CurrentlySelected && o.ClientNumber == clientNumber) != null;
+        }
+        #endregion
+        #region Constructor
+        public LinkedAccountOperations(Requestor requestor)
+        {
+            _requestor = requestor;
+        }
+        #endregion
+    }
+}

--- a/src/HL.Client/Utilities/ContractNoteParser.cs
+++ b/src/HL.Client/Utilities/ContractNoteParser.cs
@@ -1,0 +1,444 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using HL.Client.Entities;
+using PdfSharp.Pdf.Advanced;
+using PdfSharp.Pdf.Content;
+using PdfSharp.Pdf.Content.Objects;
+using PdfSharp.Pdf.IO;
+
+namespace HL.Client.Utilities
+{
+    /// <summary>
+    /// Defines the element type found in the PDF.
+    /// </summary>
+    internal enum ElementType
+    {
+        Unknown,
+        ClientName,
+        AddressLine1,
+        AddressLine2,
+        AddressLine3,
+        AddressLine4,
+        AddressLine5,
+        AddressLine6,
+        AccountName,
+        SettlementDate,
+        ContractNoteId,
+        OrderDate,
+        OrderTime,
+        PriceDetailType1,
+        PriceDetailValue1,
+        PriceDetailType2,
+        PriceDetailValue2,
+        PriceDetailType3,
+        PriceDetailValue3,
+        FeeType1,
+        FeeValue1,
+        FeeType2,
+        FeeValue2,
+        FeeType3,
+        FeeValue3,
+        FeeType4,
+        FeeValue4,
+        OrderDetailNote1,
+        OrderDetailNote2,
+        OrderDetailNote3,
+        OrderDetailNote4,
+        Isin,
+        UnitName,
+        UnitType,
+        UnitPrice,
+        NoteLine1,
+        NoteLine2,
+        StockCode,
+        TransactionType,
+        Quantity,
+        TotalAmountIncludingFees,
+        TotalAmountExcludingFees,
+    }
+
+    /// <summary>
+    /// A helper class for parsing contract note PDF files.
+    /// </summary>
+    public class ContractNoteParser
+    {
+        private static readonly Dictionary<(double, double), ElementType> CoordinatesToElementTypes =
+            new Dictionary<(double, double), ElementType>
+            {
+                { (62.36, 687.4), ElementType.ClientName },
+                { (62.36, 677.48), ElementType.AddressLine1 },
+                { (62.36, 667.56), ElementType.AddressLine2 },
+                { (62.36, 657.64), ElementType.AddressLine3 },
+                { (62.36, 647.72), ElementType.AddressLine4 },
+                { (62.36, 637.80), ElementType.AddressLine5 },
+                { (62.36, 627.88), ElementType.AddressLine6 },
+                { (34.02, 158.03), ElementType.AccountName },
+                { (374.17, 158.03), ElementType.SettlementDate },
+                { (433.7, 582.52), ElementType.ContractNoteId },
+                { (56.69, 582.52), ElementType.OrderDate },
+                { (249.45, 582.52), ElementType.OrderTime },
+                { (493.94, 290.55), ElementType.FeeValue1 },
+                { (493.94, 280.63), ElementType.FeeValue2 },
+                { (493.94, 270.71), ElementType.FeeValue3 },
+                { (493.94, 260.79), ElementType.FeeValue4 },
+                { (119.06, 290.55), ElementType.FeeType1 },
+                { (119.06, 280.63), ElementType.FeeType2 },
+                { (119.06, 270.71), ElementType.FeeType3 },
+                { (119.06, 260.79), ElementType.FeeType4 },
+                { (119.06, 323.15), ElementType.OrderDetailNote1 },
+                { (119.06, 333.07), ElementType.OrderDetailNote2 },
+                { (119.06, 342.99), ElementType.OrderDetailNote3 },
+                { (119.06, 352.91), ElementType.OrderDetailNote4 },
+                { (119.06, 454.96), ElementType.Isin },
+                { (119.06, 445.04), ElementType.UnitName },
+                { (119.06, 435.12), ElementType.UnitType },
+                { (119.06, 398.27), ElementType.PriceDetailType1 },
+                { (119.06, 388.35), ElementType.PriceDetailType2 },
+                { (119.06, 378.43), ElementType.PriceDetailType3 },
+                { (388.35, 398.27), ElementType.PriceDetailValue1 },
+                { (388.35, 388.35), ElementType.PriceDetailValue2 },
+                { (388.35, 378.43), ElementType.PriceDetailValue3 },
+                { (31.18, 123.44), ElementType.NoteLine1 },
+                { (31.18, 109.27), ElementType.NoteLine2 },
+            };
+
+        private static readonly HashSet<(double, double)> Ignored = new HashSet<(double, double)>
+        {
+            (249.45, 593.86),
+            (347.81, 435.83),
+        };
+
+        private static ElementType GetElementTypeFromCoordinates(double x, double y)
+        {
+            if (y == 454.82)
+            {
+                return ElementType.StockCode;
+            }
+
+            if (x > 250 && x < 280 && y == 538.58)
+            {
+                return ElementType.TransactionType;
+            }
+
+            if (x < 100 && y == 435.83)
+            {
+                return ElementType.Quantity;
+            }
+
+            if (x > 400 && y == 158.03)
+            {
+                return ElementType.TotalAmountIncludingFees;
+            }
+
+            if (x > 450 && x < 500 && (y == 371.34 || y == 435.83))
+            {
+                return ElementType.TotalAmountExcludingFees;
+            }
+
+            if (x > 360 && x < 390 && y == 435.83)
+            {
+                return ElementType.UnitPrice;
+            }
+
+            if (CoordinatesToElementTypes.TryGetValue((x, y), out ElementType elementType))
+            {
+                return elementType;
+            }
+
+            return ElementType.Unknown;
+        }
+
+        private static Dictionary<ElementType, string> GetTokensForElements(byte[] data)
+        {
+            Dictionary<ElementType, string> output = new Dictionary<ElementType, string>();
+            using (var stream = new MemoryStream(data))
+            {
+                var doc = PdfReader.Open(stream, PdfDocumentOpenMode.ReadOnly);
+                foreach (var page in doc.Pages)
+                {
+                    foreach (PdfContent pageContent in page.Contents)
+                    {
+                        pageContent.Compressed = false;
+                        byte[] dataBytes = pageContent.Stream.Value;
+                        var parser = new CParser(dataBytes);
+                        double x = double.NaN;
+                        double y = double.NaN;
+                        string lineContent = null;
+                        foreach (var t in parser.ReadContent())
+                        {
+                            if (t is COperator op)
+                            {
+                                if (op.OpCode.OpCodeName == OpCodeName.q)
+                                {
+                                    x = double.NaN;
+                                    y = double.NaN;
+                                    lineContent = null;
+                                }
+
+                                if (op.OpCode.OpCodeName == OpCodeName.Td && op.Operands.Count == 2 &&
+                                    op.Operands[0] is CReal cx && op.Operands[1] is CReal cy)
+                                {
+                                    x = cx.Value;
+                                    y = cy.Value;
+                                }
+
+                                if (op.OpCode.OpCodeName == OpCodeName.Tj && op.Operands[0] is CString str)
+                                {
+                                    lineContent = str.Value;
+                                }
+
+                                if (op.OpCode.OpCodeName == OpCodeName.Q && !string.IsNullOrWhiteSpace(lineContent) && !double.IsNaN(x) &&
+                                    !double.IsNaN(y))
+                                {
+                                    if (Ignored.Contains((x, y)))
+                                    {
+                                        continue;
+                                    }
+
+                                    ElementType elementType = GetElementTypeFromCoordinates(x, y);
+                                    if (elementType == ElementType.Unknown)
+                                    {
+                                        throw new Exception(
+                                            $"Failed to identify PDF item at coordinates ({x}, {y}) = {lineContent}"
+                                        );
+                                    }
+
+                                    output[elementType] = lineContent;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return output;
+        }
+
+        public static ContractNoteEntity ParseContractNote(string filePath)
+        {
+            return ParseContractNote(File.ReadAllBytes(filePath));
+        }
+
+        public static ContractNoteEntity ParseContractNote(byte[] data)
+        {
+            Dictionary<ElementType, string> tokens = GetTokensForElements(data);
+            var note = new ContractNoteEntity();
+
+            if (tokens.TryGetValue(ElementType.ClientName, out string clientName))
+            {
+                note.ClientName = clientName;
+            }
+
+            List<string> address = new List<string>();
+            for (int i = 1; i <= 6; i++)
+            {
+                if (!Enum.TryParse($"AddressLine{i}", out ElementType elementType))
+                {
+                    throw new ApplicationException($"Could not find elemet type: AddressLine{i}");
+                }
+                if (tokens.TryGetValue(elementType, out string addressLine) &&
+                    !string.IsNullOrWhiteSpace(addressLine))
+                {
+                    address.Add(addressLine);
+                }
+            }
+
+            note.ClientAddress = address.ToArray();
+
+            if (tokens.TryGetValue(ElementType.AccountName, out string accountName))
+            {
+                note.Account = accountName;
+            }
+
+            if (tokens.TryGetValue(ElementType.SettlementDate, out string settlementDate))
+            {
+                note.SettlementDate = DateTime.ParseExact(settlementDate, "dd/MM/yyyy", CultureInfo.InvariantCulture);
+            }
+
+            if (tokens.TryGetValue(ElementType.TransactionType, out string transactionType))
+            {
+                if (transactionType.Contains("BOUGHT"))
+                {
+                    note.TransactionType = TransactionType.Buy;
+                }
+                else if (transactionType.Contains("SOLD"))
+                {
+                    note.TransactionType = TransactionType.Sell;
+                }
+                else
+                {
+                    throw new Exception($"Unknown transaction type: {transactionType}");
+                }
+            }
+
+            if (tokens.TryGetValue(ElementType.ContractNoteId, out string contractNoteId))
+            {
+                note.ContractNoteId = contractNoteId;
+            }
+
+            if (tokens.TryGetValue(ElementType.OrderDate, out string orderDate))
+            {
+                var orderDateParsed = DateTime.ParseExact(orderDate, "dd/MM/yyyy", CultureInfo.InvariantCulture);
+                if (tokens.TryGetValue(ElementType.OrderTime, out string orderTime))
+                {
+                    int[] parts = orderTime.Split(':').Select(int.Parse).ToArray();
+                    orderDateParsed = orderDateParsed.AddHours(parts[0]).AddMinutes(parts[1]);
+                }
+
+                note.OrderTime = orderDateParsed;
+            }
+
+            if (tokens.TryGetValue(ElementType.UnitName, out string unitName))
+            {
+                note.UnitName = unitName;
+            }
+
+            if (tokens.TryGetValue(ElementType.UnitType, out string unitType))
+            {
+                note.UnitType = unitType;
+            }
+
+            if (tokens.TryGetValue(ElementType.Quantity, out string quantity))
+            {
+                note.Quantity = double.Parse(quantity);
+            }
+
+            if (tokens.TryGetValue(ElementType.Isin, out string token))
+            {
+                note.Isin = token;
+            }
+
+            if (tokens.TryGetValue(ElementType.NoteLine1, out string noteLine1))
+            {
+                note.Note = noteLine1;
+            }
+
+            if (tokens.TryGetValue(ElementType.NoteLine2, out string noteLine2))
+            {
+                if (!string.IsNullOrWhiteSpace(note.Note))
+                {
+                    note.Note += " " + noteLine2;
+                }
+                else
+                {
+                    note.Note = noteLine2;
+                }
+            }
+
+            for (int i = 1; i <= 3; i++)
+            {
+                if (!Enum.TryParse($"PriceDetailType{i}", out ElementType priceDetailTypeElementType))
+                {
+                    throw new ApplicationException($"Could not find elemet type: PriceDetailType{i}");
+                }
+
+                if (!Enum.TryParse($"PriceDetailValue{i}", out ElementType priceDetailValueElementType))
+                {
+                    throw new ApplicationException($"Could not find elemet type: PriceDetailValue{i}");
+                }
+
+                tokens.TryGetValue(priceDetailTypeElementType, out string priceDetailType);
+                tokens.TryGetValue(priceDetailValueElementType, out string priceDetailValue);
+
+                if (priceDetailType == "Price (pence)")
+                {
+                    note.UnitPriceGbp = double.Parse(priceDetailValue) / 100;
+                }
+                else if (priceDetailType != null && priceDetailType.StartsWith("Price"))
+                {
+                    note.UnitPrice = double.Parse(priceDetailValue);
+                    note.UnitCurrency = priceDetailType.Split(' ').Last().Replace("(", "").Replace(")", "");
+                }
+                else if (priceDetailType == "Exchange rate")
+                {
+                    note.ExchangeRate = double.Parse(priceDetailValue);
+                }
+            }
+
+            for (int i = 1; i <= 4; i++)
+            {
+                if (!Enum.TryParse($"FeeType{i}", out ElementType feeTypeElementType))
+                {
+                    throw new ApplicationException($"Could not find elemet type: PriceDetailType{i}");
+                }
+
+                if (!Enum.TryParse($"FeeValue{i}", out ElementType feeValueElementType))
+                {
+                    throw new ApplicationException($"Could not find elemet type: PriceDetailValue{i}");
+                }
+
+                tokens.TryGetValue(feeTypeElementType, out string feeType);
+                tokens.TryGetValue(feeValueElementType, out string feeValue);
+
+                if (feeType == "Commission")
+                {
+                    note.Commission = double.Parse(feeValue);
+                }
+                else if (feeType == "FX Charge")
+                {
+                    note.FxCharge = double.Parse(feeValue);
+                }
+                else if (feeType == "Transfer Stamp")
+                {
+                    note.TransferFee = double.Parse(feeValue);
+                }
+
+                if (!Enum.TryParse($"OrderDetailNote{i}", out ElementType orderDetailNoteElementType))
+                {
+                    throw new ApplicationException($"Could not find elemet type: OrderDetailNote{i}");
+                }
+
+                if (tokens.TryGetValue(orderDetailNoteElementType, out string orderDetailsNote))
+                {
+                    if (orderDetailsNote.EndsWith("Order"))
+                    {
+                        note.OrderType = orderDetailsNote;
+                    }
+                    else if (orderDetailsNote.StartsWith("Venue of Execution:"))
+                    {
+                        note.Venue = orderDetailsNote.Replace("Venue of Execution:", "").Trim();
+                    }
+                }
+            }
+
+            if (tokens.TryGetValue(ElementType.StockCode, out string stockCode))
+            {
+                note.Symbol = stockCode.Replace("STOCK CODE:", "").Trim();
+            }
+
+            if (tokens.TryGetValue(ElementType.TotalAmountIncludingFees, out string totalAmountIncludingFees))
+            {
+                note.TotalAmountGbpIncludingFees = double.Parse(totalAmountIncludingFees);
+            }
+
+            if (tokens.TryGetValue(ElementType.TotalAmountExcludingFees, out string totalAmountExcludingFees))
+            {
+                note.TotalAmountGbpExcludingFees = double.Parse(totalAmountExcludingFees.Replace("GBP", "").Trim());
+            }
+
+            if (tokens.TryGetValue(ElementType.UnitPrice, out var unitPrice))
+            {
+                if (note.UnitPrice == default)
+                {
+                    note.UnitPrice = double.Parse(unitPrice);
+                }
+
+                if (note.UnitPriceGbp == default)
+                {
+                    note.UnitPriceGbp = double.Parse(unitPrice);
+                }
+
+                if (note.UnitCurrency == default)
+                {
+                    note.UnitCurrency = "GBP";
+                }
+            }
+
+
+            return note;
+        }
+    }
+}

--- a/src/HL.Client/Utilities/ContractNoteParser.cs
+++ b/src/HL.Client/Utilities/ContractNoteParser.cs
@@ -303,7 +303,7 @@ namespace HL.Client.Utilities
 
             if (tokens.TryGetValue(ElementType.Quantity, out string quantity))
             {
-                note.Quantity = double.Parse(quantity);
+                note.Quantity = decimal.Parse(quantity);
             }
 
             if (tokens.TryGetValue(ElementType.Isin, out string token))
@@ -345,16 +345,16 @@ namespace HL.Client.Utilities
 
                 if (priceDetailType == "Price (pence)")
                 {
-                    note.UnitPriceGbp = double.Parse(priceDetailValue) / 100;
+                    note.UnitPriceGbp = decimal.Parse(priceDetailValue) / 100;
                 }
                 else if (priceDetailType != null && priceDetailType.StartsWith("Price"))
                 {
-                    note.UnitPrice = double.Parse(priceDetailValue);
+                    note.UnitPrice = decimal.Parse(priceDetailValue);
                     note.UnitCurrency = priceDetailType.Split(' ').Last().Replace("(", "").Replace(")", "");
                 }
                 else if (priceDetailType == "Exchange rate")
                 {
-                    note.ExchangeRate = double.Parse(priceDetailValue);
+                    note.ExchangeRate = decimal.Parse(priceDetailValue);
                 }
             }
 
@@ -375,15 +375,15 @@ namespace HL.Client.Utilities
 
                 if (feeType == "Commission")
                 {
-                    note.Commission = double.Parse(feeValue);
+                    note.Commission = decimal.Parse(feeValue);
                 }
                 else if (feeType == "FX Charge")
                 {
-                    note.FxCharge = double.Parse(feeValue);
+                    note.FxCharge = decimal.Parse(feeValue);
                 }
                 else if (feeType == "Transfer Stamp")
                 {
-                    note.TransferFee = double.Parse(feeValue);
+                    note.TransferFee = decimal.Parse(feeValue);
                 }
 
                 if (!Enum.TryParse($"OrderDetailNote{i}", out ElementType orderDetailNoteElementType))
@@ -411,24 +411,24 @@ namespace HL.Client.Utilities
 
             if (tokens.TryGetValue(ElementType.TotalAmountIncludingFees, out string totalAmountIncludingFees))
             {
-                note.TotalAmountGbpIncludingFees = double.Parse(totalAmountIncludingFees);
+                note.TotalAmountGbpIncludingFees = decimal.Parse(totalAmountIncludingFees);
             }
 
             if (tokens.TryGetValue(ElementType.TotalAmountExcludingFees, out string totalAmountExcludingFees))
             {
-                note.TotalAmountGbpExcludingFees = double.Parse(totalAmountExcludingFees.Replace("GBP", "").Trim());
+                note.TotalAmountGbpExcludingFees = decimal.Parse(totalAmountExcludingFees.Replace("GBP", "").Trim());
             }
 
             if (tokens.TryGetValue(ElementType.UnitPrice, out var unitPrice))
             {
                 if (note.UnitPrice == default)
                 {
-                    note.UnitPrice = double.Parse(unitPrice);
+                    note.UnitPrice = decimal.Parse(unitPrice);
                 }
 
                 if (note.UnitPriceGbp == default)
                 {
-                    note.UnitPriceGbp = double.Parse(unitPrice);
+                    note.UnitPriceGbp = decimal.Parse(unitPrice);
                 }
 
                 if (note.UnitCurrency == default)

--- a/src/HL.Client/Utilities/CsvSerializer.cs
+++ b/src/HL.Client/Utilities/CsvSerializer.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace HL.Client.Utilities
+{
+    public static class CsvSerializer
+    {
+        /// <summary>
+        /// Serialize objects to Comma Separated Value (CSV) format [1].
+        /// 
+        /// Rather than try to serialize arbitrarily complex types with this
+        /// function, it is better, given type A, to specify a new type, A'.
+        /// Have the constructor of A' accept an object of type A, then assign
+        /// the relevant values to appropriately named fields or properties on
+        /// the A' object.
+        /// 
+        /// [1] http://tools.ietf.org/html/rfc4180
+        /// </summary>
+        public static void Serialize<T>(TextWriter output, IEnumerable<T> objects)
+        {
+            var fields = typeof(T).GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+                .Where(mi => new[] { MemberTypes.Field, MemberTypes.Property }.Contains(mi.MemberType))
+                .ToArray();
+            output.WriteLine(QuoteRecord(fields.Select(f => f.Name)));
+            foreach (var record in objects)
+            {
+                output.WriteLine(QuoteRecord(FormatObject(fields, record)));
+            }
+        }
+
+        private static IEnumerable<string> FormatObject<T>(IEnumerable<MemberInfo> fields, T record)
+        {
+            foreach (var field in fields)
+            {
+                if (field is FieldInfo fi)
+                {
+                    yield return Convert.ToString(fi.GetValue(record));
+                }
+                else if (field is PropertyInfo pi)
+                {
+                    yield return Convert.ToString(pi.GetValue(record, null));
+                }
+                else
+                {
+                    throw new Exception("Unhandled case.");
+                }
+            }
+        }
+
+        private const string CsvSeparator = ",";
+
+        static string QuoteRecord(IEnumerable<string> record)
+        {
+            return string.Join(CsvSeparator, record.Select(QuoteField).ToArray());
+        }
+
+        static string QuoteField(string field)
+        {
+            if (string.IsNullOrEmpty(field))
+            {
+                return "\"\"";
+            }
+
+            if (field.Contains(CsvSeparator) || field.Contains("\"") || field.Contains("\r") ||
+                field.Contains("\n"))
+            {
+                return $"\"{field.Replace("\"", "\"\"")}\"";
+            }
+
+            return field;
+        }
+    }
+}


### PR DESCRIPTION
Also:
1. Fix an exception when an account has no holdings
2. Remove the Console.ReadLine() from example. Whoever is able to run the example was able to compile it, which was already  done in either a terminal, or in an IDE, at which point there is no point to wait for input. Makes the Modify -> Run -> Modify run development loop annoying as you always have to provide the input.